### PR TITLE
Speed up folding the project contexts

### DIFF
--- a/src/NoRecordAliasConstructor.elm
+++ b/src/NoRecordAliasConstructor.elm
@@ -278,8 +278,7 @@ translateContexts =
             , constructorUses =
                 a.constructorUses ++ b.constructorUses
             , modulesExposingAll =
-                a.modulesExposingAll
-                    |> Dict.union b.modulesExposingAll
+                Dict.union a.modulesExposingAll b.modulesExposingAll
             }
     }
 


### PR DESCRIPTION
`Dict.union old new` is very much like for lists' `old ++ new`. If the left is super small, it will be super fast, If the left is long, it will take a long time. So `[1, ...., 10000 ] ++ [ 0 ]` will be extremely slow, while `[ 0 ] ++ [1, ...., 10000 ]` will be extremely fast. And the same is true for `Dict.union`. Since the accumulator is `b` in this case (and the context to add is `a`), we want to make sure `b` is the second argument (the one we will not iterate on.

On projects with 1000 modules, this will cause 1000 insertions in the accumulated dict when doing the final evaluation of the project, instead of 500,000 (1000*1000 / 2 would be my estimated calculation)