### PR TITLE
Speed up folding

### DIFF
--- a/src/NoRecordAliasConstructor.elm
+++ b/src/NoRecordAliasConstructor.elm
@@ -272,8 +272,7 @@ translateContexts =
         \a b ->
             { modulesRecordTypeAliases = a.modulesRecordTypeAliases |> Dict.union b.modulesRecordTypeAliases
             , modulesExposingAll =
-                a.modulesExposingAll
-                    |> Dict.union b.modulesExposingAll
+                Dict.union a.modulesExposingAll b.modulesExposingAll
             }
     }
 


### PR DESCRIPTION
`Dict.union` is slower when the first argument is the bigger dictionary. In this case, since `b` is the accumulator, it is the bigger dictionary.
Keeping the old order roughly squares the number of `Dict.insert` that will be performed (500,000 instead of 1000 if you have 1000 modules). Changing the order of this operation has done wonders for rules like `NoUnused.Variables`